### PR TITLE
Added support for official Xbox 360 wired gamepad, updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # utils
 
 Various useful utilities
+
+# Dependencies
+
+```bash
+pip install inputs
+```
+# Supported gamepads
+
+- Logitech Gamepad F710
+- Microsoft X-Box 360 pad

--- a/vtils/input/gamepad.py
+++ b/vtils/input/gamepad.py
@@ -6,7 +6,11 @@ monitor_events = [  'ABS_X', 'ABS_Y',
                     'ABS_HAT0X', 'ABS_HAT0Y',
                     'ABS_RY', 'ABS_RX',
                     'BTN_EAST', 'BTN_WEST', 'BTN_NORTH', 'BTN_SOUTH',
-                    'BTN_TL', 'BTN_TR']
+                    'BTN_TL', 'BTN_TR',
+                    'BTN_START', 'BTN_SELECT',
+                    'BTN_THUMBL', 'BTN_THUMBR',
+                    'BTN_MODE', # Home (XBox) menu button
+                    "ABS_Z", 'ABS_RZ'] # NOTE: might be specific to Xbox 360 analog triggers
 
 class GamePad():
     """
@@ -17,7 +21,7 @@ class GamePad():
     def __init__(self):
         if self._GAMEPAD_CLIENT is None:
             for device in devices:
-                if device.name == "Logitech Gamepad F710":
+                if device.name in ["Logitech Gamepad F710", "Microsoft X-Box 360 pad"]:
                     self._GAMEPAD_CLIENT = device
                     print("Gamepad {} found".format(device))
             if self._GAMEPAD_CLIENT is None:
@@ -52,14 +56,17 @@ class GamePad():
 
     def read_sensor(self):
         events = self._GAMEPAD_CLIENT.read()
-
+        
+        # TODO: make the analog axis return normalized float for finer control ?
         for event in events:
             if event.code in monitor_events:
                 self.sensor_data['is_new'] = True # mark addition of new data
-                if event.code is 'ABS_RX' or event.code is 'ABS_RY':
-                    self.sensor_data[event.code] = event.state/32767
-                elif event.code is 'ABS_X' or event.code is 'ABS_Y':
-                    self.sensor_data[event.code] = int(event.state/32767)
+                if event.code == 'ABS_RX' or event.code == 'ABS_RY':
+                    self.sensor_data[event.code] = event.state/32767.0
+                elif event.code == 'ABS_X' or event.code == 'ABS_Y':
+                    self.sensor_data[event.code] = event.state/32767.0
+                elif event.code == 'ABS_RZ' or event.code == "ABS_Z":
+                    self.sensor_data[event.code] = event.state/255.0
                 else:
                     self.sensor_data[event.code] = event.state
             # else:

--- a/vtils/input/gamepad.py
+++ b/vtils/input/gamepad.py
@@ -10,7 +10,7 @@ monitor_events = [  'ABS_X', 'ABS_Y',
                     'BTN_START', 'BTN_SELECT',
                     'BTN_THUMBL', 'BTN_THUMBR',
                     'BTN_MODE', # Home (XBox) menu button
-                    "ABS_Z", 'ABS_RZ'] # NOTE: might be specific to Xbox 360 analog triggers
+                    "ABS_Z", 'ABS_RZ']
 
 class GamePad():
     """
@@ -57,7 +57,6 @@ class GamePad():
     def read_sensor(self):
         events = self._GAMEPAD_CLIENT.read()
         
-        # TODO: make the analog axis return normalized float for finer control ?
         for event in events:
             if event.code in monitor_events:
                 self.sensor_data['is_new'] = True # mark addition of new data


### PR DESCRIPTION
Hello again @vikashplus 

Thanks for the tip in #2 , managed to get it work by installing the missing `inputs` dependency.

This PR adds
- a section for dependencies install, as well as support controllers.
- `gamepad.py` now supports the wired `Microsoft X-Box 360 Controller`
- Analog stick and trigger values were changed from discrete to (normalized) continuous values, allowing a fine grained control of end effector during tele operation.

Tested the changes with robohive;s ee_teleop.py script.
Unfortunately I could not test with the default "Logitech F710" controller, but I am pretty sure it will still work since I only added additional buttons and triggers for the X360 controller.

If case you are open to it, I could also do a PR on robohive's tutorials/ee_teleop to add the polling function for the gamepad.

Hope this can be useful down the road.