### PR TITLE
Fixed typo in spacemouse dependency installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Various useful utilities
 
 ```bash
 pip install inputs # Gamepads
-pip install hdiapi # Spacemouse, Linux documentation linked below.
+pip install hidapi # Spacemouse, Linux documentation linked below.
 ```
 
 # Supported devices for Robohive tele-operation

--- a/vtils/input/README.md
+++ b/vtils/input/README.md
@@ -29,10 +29,10 @@ For Linux support, you can find open-source Linux drivers and SDKs online at htt
 
 **Dependencies**
 
-Install `hdiapi` on Linux to enable access to the spacemouse device using the `hdi` API in Python.
+Install `hidapi` on Linux to enable access to the spacemouse device using the `hid` API in Python.
 
 ```bash
-pip install hdiapi
+pip install hidapi
 ```
 
 Install and configure the open-source spacenav daemon `spnavd`:


### PR DESCRIPTION
Hello @vikashplus 

I was going over the notes for setting up the spacemouse on Linux and happened to find a typo in the install instructions.
Namely, I used `pip install hdiapi` in the previous PR, while it should have been `pip install hidapi`
This PR fixes that typo in both the main README, as well as the input/README.

Best regards.